### PR TITLE
Suggestion: Make the Toad dialog from the perspective of peach

### DIFF
--- a/XMLLanguage_en.xml
+++ b/XMLLanguage_en.xml
@@ -3184,9 +3184,9 @@ You can live without \n, but certain balloons will be 'very empty' without them,
 				<f i="2">Princess....I need to do something in....your back thighs!</f>
 				<p i="3">Ask him to... cure my asshole</p>
 				<p i="4">Be lewd so he will play with my butt</p>
-				<p i="5">Help him with my hands</p>
+				<p i="5">Hand Relieve </p>
 				<p i="6">Do you ask a massage, or do you relieve him?</p>
-				<p i="7">2) Relieve with my mouth  3) Kneel and get a frontal massage 4) Lie down and get a butt massage\n5) Kneel and get a butt massage!  6) Relieve his dick with your ass (he might slip)!  7) Let him choose!  ({NEXTKEY}) GO AWAY</p>
+				<p i="7">2) Mouth Relieve 3) Fontal Massage 4) Lying massage\n5) Kneeling massage  6) Ass Relieve (he might slip!)  7) Let him choose!  ({NEXTKEY}) GO AWAY</p>
 			</scenes>			
 				
 			<scenes scene="dialogueGloryHole">

--- a/XMLLanguage_en.xml
+++ b/XMLLanguage_en.xml
@@ -3180,13 +3180,13 @@ You can live without \n, but certain balloons will be 'very empty' without them,
 			</scenes>
 
 			<scenes scene="dialogueToad1">
-				<f i="1">Princess....I feel you need my help! You...might be having a gaping asshole problem!</f>
+				<f i="1">Princess....I feel you need my help! You...might have a gaping asshole problem!</f>
 				<f i="2">Princess....I need to do something in....your back thighs!</f>
 				<p i="3">Ask him to... cure my asshole</p>
 				<p i="4">Be lewd so he will play with my butt</p>
 				<p i="5">Help him with my hands</p>
-				<p i="6">What to do?</p>
-				<p i="7">2) Make her suck you  3) Tease her  4) Tease her more\n5) Tease her even more!  6) Slip in her asshole!  7) Let him choose!  ({NEXTKEY}) GO AWAY</p>
+				<p i="6">Do you ask a massage, or do you relieve him?</p>
+				<p i="7">2) Relieve with my mouth  3) Kneel and get a frontal massage 4) Lie down and get a butt massage\n5) Kneel and get a butt massage!  6) Relieve his dick with your ass (he might slip)!  7) Let him choose!  ({NEXTKEY}) GO AWAY</p>
 			</scenes>			
 				
 			<scenes scene="dialogueGloryHole">


### PR DESCRIPTION
This is proposed change for the dialog when Peach talks to Toads. This changes the dialog to be from the perspective of Peach.
The text is not yet ideal. But in my opinion it's an improvement. I've tested it, and it fits in the dialog box, so that's good :-)

All my other commits up to now where spelling and other error fixes, but this one is not. So it's best to carefully review this one, to see if you agree with this change. No problem if you don't want this change.

Another possible fix to the "perspective" problem, is to split the dialog, and somehow let peach first decide if she wants to "relieve" the Toad, or if she wants to get a massage (a nymph peach might also have an option to go for sex directly). And then in the second step, have a few options for each of these. But off course, that's not possible by only changing `XMLLanguage_en.xml`.